### PR TITLE
Fixed an error when stopping following tokens in V12

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "FollowMe",
   "title": "Follow Me!",
   "description": "Allows tokens to follow other tokens.",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "authors": [
     {
       "name": "o_Ove",
@@ -38,6 +38,6 @@
   "readme": "README.md",
   "compatibility": {
     "minimum": "10",
-    "verified": "10"
+    "verified": "12"
   }
 }

--- a/script/followme.mjs
+++ b/script/followme.mjs
@@ -68,7 +68,7 @@ function stopFollowing( token, whom, collided = false ){
     scrollText(token.object, strTemplate(lang("stopped"), {name:whom}));
   }
   if (token.isOwner){
-    token.setFlag(MOD_NAME, FLAG_FOLLOWING, null);
+    token.unsetFlag(MOD_NAME, FLAG_FOLLOWING);
   }
 }
 


### PR DESCRIPTION
There was an error when unsetting the follow me flag by putting it to null, and later updating it again. This causes issues with later versions of foundry. Calling `unsetFlag` works instead.